### PR TITLE
Added DPDK reference architecture templates for OSP11

### DIFF
--- a/osp11_ref/deploy.sh
+++ b/osp11_ref/deploy.sh
@@ -1,0 +1,6 @@
+openstack overcloud deploy --templates \
+    --timeout 90 \
+    -e /usr/share/openstack-tripleo-heat-templates/environments/neutron-ovs-dpdk.yaml \
+    -e /usr/share/openstack-tripleo-heat-templates/environments/network-isolation.yaml \
+    -e network-environment.yaml
+

--- a/osp11_ref/first-boot.yaml
+++ b/osp11_ref/first-boot.yaml
@@ -1,0 +1,259 @@
+heat_template_version: 2014-10-16
+
+description: >
+  This is an example showing how you can do firstboot configuration
+  of the nodes via cloud-init.  To enable this, replace the default
+  mapping of OS::TripleO::NodeUserData in ../overcloud_resource_registry*
+
+parameters:
+  ComputeKernelArgs:
+    description: >
+      Space seprated list of Kernel args to be update to grub.
+      The given args will be appended to existing args of GRUB_CMDLINE_LINUX in file /etc/default/grub
+      Example: "intel_iommu=on default_hugepagesz=1GB hugepagesz=1G hugepages=1"
+    type: string
+    default: ""
+  ComputeHostnameFormat:
+    type: string
+    default: ""
+  HostIsolatedCoreList:
+    description: >
+      A list or range of physical CPU cores to be tuned as isolated_cores.
+      The given args will be appended to the tuned cpu-partitioning profile.
+      Ex. HostIsolatedCoreList: '4-12' will tune cores from 4-12
+    type: string
+    default: ""
+  HostCpusList:
+    description: >
+      A list or range of physical CPU cores to be tuned.
+      The given args will be appended to the tuned cpu-partitioning profile.
+      Ex. HostCpusList: '4-12' will tune cores from 4-12
+    type: string
+    default: ""
+  NeutronDpdkCoreList:
+    description: >
+      List of logical cores for PMD threads. Its mandatory parameter.
+    type: string
+  NeutronDpdkSocketMemory:
+    description: Memory allocated for each socket
+    default: ""
+    type: string
+  NeutronVhostuserSocketDir:
+    description: The vhost-user socket directory for OVS.
+    default: ""
+    type: string
+  NovaVcpuPinSet:
+    description: >
+      A list or range of physical CPU cores to reserve for virtual machine
+      processes.
+      Ex. NovaVcpuPinSet: ['4-12','^8'] will reserve cores from 4-12 excluding 8
+    type: comma_delimited_list
+    default: []
+
+resources:
+  userdata:
+    type: OS::Heat::MultipartMime
+    properties:
+      parts:
+      - config: {get_resource: set_ovs_socket_config}
+      - config: {get_resource: set_ovs_config}
+      - config: {get_resource: set_dpdk_params}
+      - config: {get_resource: install_tuned}
+      - config: {get_resource: compute_kernel_args}
+
+  set_ovs_socket_config:
+    type: OS::Heat::SoftwareConfig
+    properties:
+      config:
+        str_replace:
+          template: |
+            #!/bin/bash
+            set -x
+            FORMAT=$COMPUTE_HOSTNAME_FORMAT
+            if [[ -z $FORMAT ]] ; then
+              FORMAT="compute" ;
+            else
+              # Assumption: only %index% and %stackname% are the variables in Host name format
+              FORMAT=$(echo $FORMAT | sed  's/\%index\%//g' | sed 's/\%stackname\%//g') ;
+            fi
+            if [[ $(hostname) == *$FORMAT* ]] ; then
+              mkdir -p $NEUTRON_VHOSTUSER_SOCKET_DIR
+              chown -R qemu:qemu $NEUTRON_VHOSTUSER_SOCKET_DIR
+              restorecon $NEUTRON_VHOSTUSER_SOCKET_DIR
+            fi
+          params:
+            $COMPUTE_HOSTNAME_FORMAT: {get_param: ComputeHostnameFormat}
+            $NEUTRON_VHOSTUSER_SOCKET_DIR: {get_param: NeutronVhostuserSocketDir}
+
+  set_ovs_config:
+    type: OS::Heat::SoftwareConfig
+    properties:
+      config:
+        str_replace:
+          template: |
+            #!/bin/bash
+            FORMAT=$COMPUTE_HOSTNAME_FORMAT
+            if [[ -z $FORMAT ]] ; then
+              FORMAT="compute" ;
+            else
+              # Assumption: only %index% and %stackname% are the variables in Host name format
+              FORMAT=$(echo $FORMAT | sed  's/\%index\%//g' | sed 's/\%stackname\%//g') ;
+            fi
+            if [[ $(hostname) == *$FORMAT* ]] ; then
+              if [ -f /usr/lib/systemd/system/openvswitch-nonetwork.service ]; then
+                ovs_service_path="/usr/lib/systemd/system/openvswitch-nonetwork.service"
+              elif [ -f /usr/lib/systemd/system/ovs-vswitchd.service ]; then
+                ovs_service_path="/usr/lib/systemd/system/ovs-vswitchd.service"
+              fi
+              grep -q "RuntimeDirectoryMode=.*" $ovs_service_path
+              if [ "$?" -eq 0 ]; then
+                sed -i 's/RuntimeDirectoryMode=.*/RuntimeDirectoryMode=0775/' $ovs_service_path
+              else
+                echo "RuntimeDirectoryMode=0775" >> $ovs_service_path
+              fi
+              grep -Fxq "Group=qemu" $ovs_service_path
+              if [ ! "$?" -eq 0 ]; then
+                echo "Group=qemu" >> $ovs_service_path
+              fi
+              grep -Fxq "UMask=0002" $ovs_service_path
+              if [ ! "$?" -eq 0 ]; then
+                echo "UMask=0002" >> $ovs_service_path
+              fi
+              ovs_ctl_path='/usr/share/openvswitch/scripts/ovs-ctl'
+              grep -q "umask 0002 \&\& start_daemon \"\$OVS_VSWITCHD_PRIORITY\"" $ovs_ctl_path
+              if [ ! "$?" -eq 0 ]; then
+                sed -i 's/start_daemon \"\$OVS_VSWITCHD_PRIORITY.*/umask 0002 \&\& start_daemon \"$OVS_VSWITCHD_PRIORITY\" \"$OVS_VSWITCHD_WRAPPER\" \"$@\"/' $ovs_ctl_path
+              fi
+            fi
+          params:
+            $COMPUTE_HOSTNAME_FORMAT: {get_param: ComputeHostnameFormat}
+
+  # Verify the logs on /var/log/cloud-init.log on the overcloud node
+  set_dpdk_params:
+    type: OS::Heat::SoftwareConfig
+    properties:
+      config:
+        str_replace:
+          template: |
+            #!/bin/bash
+            set -x
+            get_mask()
+            {
+              local list=$1
+              local mask=0
+              declare -a bm
+              max_idx=0
+              for core in $(echo $list | sed 's/,/ /g')
+              do
+                index=$(($core/32))
+                bm[$index]=0
+                if [ $max_idx -lt $index ]; then
+                   max_idx=$(($index))
+                fi
+              done
+              for ((i=$max_idx;i>=0;i--));
+              do
+                bm[$i]=0
+              done
+              for core in $(echo $list | sed 's/,/ /g')
+              do
+                index=$(($core/32))
+                temp=$((1<<$(($core % 32))))
+                bm[$index]=$((${bm[$index]} | $temp))
+              done
+              printf -v mask "%x" "${bm[$max_idx]}"
+              for ((i=$max_idx-1;i>=0;i--));
+              do
+                printf -v hex "%08x" "${bm[$i]}"
+                mask+=$hex
+              done
+              printf "%s" "$mask"
+            }
+
+            FORMAT=$COMPUTE_HOSTNAME_FORMAT
+            if [[ -z $FORMAT ]] ; then
+              FORMAT="compute" ;
+            else
+              # Assumption: only %index% and %stackname% are the variables in Host name format
+              FORMAT=$(echo $FORMAT | sed  's/\%index\%//g' | sed 's/\%stackname\%//g') ;
+            fi
+            if [[ $(hostname) == *$FORMAT* ]] ; then
+              pmd_cpu_mask=$( get_mask $PMD_CORES )
+              host_cpu_mask=$( get_mask $TUNED_CORES )
+              ovs-vsctl --no-wait set Open_vSwitch . other_config:dpdk-init=true
+              ovs-vsctl --no-wait set Open_vSwitch . other_config:dpdk-socket-mem=$SOCKET_MEMORY
+              ovs-vsctl --no-wait set Open_vSwitch . other_config:pmd-cpu-mask=$pmd_cpu_mask
+              ovs-vsctl --no-wait set Open_vSwitch . other_config:dpdk-lcore-mask=$host_cpu_mask
+            fi
+          params:
+            $COMPUTE_HOSTNAME_FORMAT: {get_param: ComputeHostnameFormat}
+            $TUNED_CORES: {get_param: HostCpusList}
+            $PMD_CORES: {get_param: NeutronDpdkCoreList}
+            $SOCKET_MEMORY: {get_param: NeutronDpdkSocketMemory}
+
+  install_tuned:
+    type: OS::Heat::SoftwareConfig
+    properties:
+      config:
+        str_replace:
+          template: |
+            #!/bin/bash
+            set -x
+            FORMAT=$COMPUTE_HOSTNAME_FORMAT
+            if [[ -z $FORMAT ]] ; then
+              FORMAT="compute" ;
+            else
+              # Assumption: only %index% and %stackname% are the variables in Host name format
+              FORMAT=$(echo $FORMAT | sed  's/\%index\%//g' | sed 's/\%stackname\%//g') ;
+            fi
+            if [[ $(hostname) == *$FORMAT* ]] ; then
+              #PMD=$PMD_CORES
+              #VCPU='$VCPU_CORES'
+              #TUNED_CORES="$PMD,$VCPU"
+
+              tuned_conf_path="/etc/tuned/cpu-partitioning-variables.conf"
+              if [ -n "$TUNED_CORES" ]; then
+                grep -q "^isolated_cores" $tuned_conf_path
+                if [ "$?" -eq 0 ]; then
+                  sed -i 's/^isolated_cores=.*/isolated_cores=$TUNED_CORES/' $tuned_conf_path
+                else
+                  echo "isolated_cores=$TUNED_CORES" >> $tuned_conf_path
+                fi
+                tuned-adm profile cpu-partitioning
+              fi
+            fi
+          params:
+            $COMPUTE_HOSTNAME_FORMAT: {get_param: ComputeHostnameFormat}
+            $TUNED_CORES: {get_param: HostIsolatedCoreList}
+
+  compute_kernel_args:
+    type: OS::Heat::SoftwareConfig
+    properties:
+      config:
+        str_replace:
+          template: |
+            #!/bin/bash
+            set -x
+            FORMAT=$COMPUTE_HOSTNAME_FORMAT
+            if [[ -z $FORMAT ]] ; then
+              FORMAT="compute" ;
+            else
+              # Assumption: only %index% and %stackname% are the variables in Host name format
+              FORMAT=$(echo $FORMAT | sed  's/\%index\%//g' | sed 's/\%stackname\%//g') ;
+            fi
+            if [[ $(hostname) == *$FORMAT* ]] ; then
+              sed 's/^\(GRUB_CMDLINE_LINUX=".*\)"/\1 $KERNEL_ARGS"/g' -i /etc/default/grub ;
+              grub2-mkconfig -o /etc/grub2.cfg
+              reboot
+            fi
+          params:
+            $KERNEL_ARGS: {get_param: ComputeKernelArgs}
+            $COMPUTE_HOSTNAME_FORMAT: {get_param: ComputeHostnameFormat}
+
+outputs:
+  # This means get_resource from the parent template will get the userdata, see:
+  # http://docs.openstack.org/developer/heat/template_guide/composition.html#making-your-template-resource-more-transparent
+  # Note this is new-for-kilo, an alternative is returning a value then using
+  # get_attr in the parent template instead.
+  OS::stack_id:
+    value: {get_resource: userdata}

--- a/osp11_ref/network-environment.yaml
+++ b/osp11_ref/network-environment.yaml
@@ -1,0 +1,64 @@
+resource_registry:
+  OS::TripleO::Compute::Net::SoftwareConfig: nic-configs/computeovsdpdk.yaml
+  OS::TripleO::Controller::Net::SoftwareConfig: nic-configs/controller.yaml
+  OS::TripleO::NodeUserData: first-boot.yaml
+  OS::TripleO::NodeExtraConfigPost: post-install.yaml
+
+parameter_defaults:
+  ControlPlaneDefaultRoute: "172.18.0.1"
+  ControlPlaneSubnetCidr: "24"
+  DnsServers: ['8.8.8.8','8.8.4.4']
+  EC2MetadataIp: "172.18.0.1"
+
+  ExternalAllocationPools: [{'start': '10.60.19.200', 'end': '10.60.19.251'}]
+  ExternalNetCidr: "10.60.19.0/24"
+  #ExternalNetworkVlanID: 10
+  NeutronExternalNetworkBridge: "''"
+  ExternalInterfaceDefaultRoute: "10.60.19.1"
+
+  InternalApiNetCidr: 10.10.81.0/24
+  StorageNetCidr: 10.10.82.0/24
+  StorageMgmtNetCidr: 10.10.83.0/24
+  TenantNetCidr: 10.10.84.0/24
+  InternalApiNetworkVlanID: 81
+  StorageNetworkVlanID: 82
+  StorageMgmtNetworkVlanID: 83
+  TenantNetworkVlanID: 84
+  InternalApiAllocationPools: [{'start': '10.10.81.20', 'end': '10.10.81.200'}]
+  StorageAllocationPools: [{'start': '10.10.82.20', 'end': '10.10.82.200'}]
+  StorageMgmtAllocationPools: [{'start': '10.10.83.20', 'end': '10.10.83.200'}]
+  TenantAllocationPools: [{'start': '10.10.84.20', 'end': '10.10.84.200'}]
+
+  ControllerCount: 1
+  ComputeCount: 1
+  OvercloudControlFlavor: control
+  OvercloudComputeFlavor: compute
+
+  # NeutronBridgeMappings translates to neutron::agents::ml2::ovs::bridge_mappings
+  NeutronBridgeMappings: "datacentre:br-ex,dpdknet:br-link"
+  # NeutronFlatNetworks translates to neutron::plugins::ml2::flat_networks
+  NeutronFlatNetworks: "datacentre"
+  # NeutronNetworkVLANRanges translates to neutron::plugins::ml2::network_vlan_ranges
+  NeutronNetworkVLANRanges: "dpdknet:100:103"
+  # NeutronNetworkType translates to neutron::plugins::ml2::tenant_network_types
+  NeutronNetworkType: ['vlan']
+  # NeutronTunnelTypes translates to neutron::agents::ml2::ovs::tunnel_types
+  NeutronTunnelTypes: ""
+
+  NeutronDpdkMemoryChannels: "4"
+
+  NeutronDatapathType: "netdev"
+  NeutronVhostuserSocketDir: "/var/lib/vhost_sockets"
+  NeutronDpdkSocketMemory: "1024,1024"
+  NeutronDpdkDriverType: "vfio-pci"
+  NovaReservedHostMemory: 4096
+  NovaSchedulerDefaultFilters: "RamFilter,ComputeFilter,AvailabilityZoneFilter,ComputeCapabilitiesFilter,ImagePropertiesFilter,PciPassthroughFilter,NUMATopologyFilter,AggregateInstanceExtraSpecsFilter"
+  ComputeKernelArgs: "default_hugepagesz=1GB hugepagesz=1G hugepages=64 intel_iommu=on"
+
+  NeutronDpdkCoreList: "10,11,22,23"
+  HostCpusList: "0,1,2,3,4,5,6,7,8,9"
+  NovaVcpuPinSet: ['12-21','24-87']
+
+  # TODO: Check if this configuration can be avoided
+  # HostIsolatedCoreList = NeutronDpdkCoreList + NovaVcpuPinSet
+  HostIsolatedCoreList: "10-87"

--- a/osp11_ref/nic-configs/computeovsdpdk.yaml
+++ b/osp11_ref/nic-configs/computeovsdpdk.yaml
@@ -1,0 +1,148 @@
+heat_template_version: 2015-04-30
+
+description: >
+  Software Config to drive os-net-config to configure VLANs for the
+  compute role.
+
+parameters:
+  ControlPlaneIp:
+    default: ''
+    description: IP address/subnet on the ctlplane network
+    type: string
+  ExternalIpSubnet:
+    default: ''
+    description: IP address/subnet on the external network
+    type: string
+  InternalApiIpSubnet:
+    default: ''
+    description: IP address/subnet on the internal API network
+    type: string
+  StorageIpSubnet:
+    default: ''
+    description: IP address/subnet on the storage network
+    type: string
+  StorageMgmtIpSubnet:
+    default: ''
+    description: IP address/subnet on the storage mgmt network
+    type: string
+  TenantIpSubnet:
+    default: ''
+    description: IP address/subnet on the tenant network
+    type: string
+  ManagementIpSubnet: # Only populated when including environments/network-management.yaml
+    default: ''
+    description: IP address/subnet on the management network
+    type: string
+  InternalApiNetworkVlanID:
+    default: 20
+    description: Vlan ID for the internal_api network traffic.
+    type: number
+  StorageNetworkVlanID:
+    default: 30
+    description: Vlan ID for the storage network traffic.
+    type: number
+  TenantNetworkVlanID:
+    default: 50
+    description: Vlan ID for the tenant network traffic.
+    type: number
+  ManagementNetworkVlanID:
+    default: 60
+    description: Vlan ID for the management network traffic.
+    type: number
+  ControlPlaneSubnetCidr: # Override this via parameter_defaults
+    default: '24'
+    description: The subnet CIDR of the control plane network.
+    type: string
+  ControlPlaneDefaultRoute: # Override this via parameter_defaults
+    description: The default route of the control plane network.
+    type: string
+  DnsServers: # Override this via parameter_defaults
+    default: []
+    description: A list of DNS servers (2 max for some implementations) that will be added to resolv.conf.
+    type: comma_delimited_list
+  EC2MetadataIp: # Override this via parameter_defaults
+    description: The IP address of the EC2 metadata server.
+    type: string
+
+resources:
+  OsNetConfigImpl:
+    type: OS::Heat::StructuredConfig
+    properties:
+      group: os-apply-config
+      config:
+        os_net_config:
+          network_config:
+            -
+              type: interface
+              name: nic2
+              use_dhcp: false
+              dns_servers: {get_param: DnsServers}
+              addresses:
+                -
+                  ip_netmask:
+                    list_join:
+                      - '/'
+                      - - {get_param: ControlPlaneIp}
+                        - {get_param: ControlPlaneSubnetCidr}
+              routes:
+                -
+                  ip_netmask: 169.254.169.254/32
+                  next_hop: {get_param: EC2MetadataIp}
+                -
+                  default: true
+                  next_hop: {get_param: ControlPlaneDefaultRoute}
+            -
+              type: interface
+              name: nic1
+              use_dhcp: false
+              defroute: false
+            -
+              type: interface
+              name: nic3
+              use_dhcp: false
+              defroute: false
+            -
+              type: interface
+              name: nic4
+              use_dhcp: false
+              defroute: false
+            -
+              type: vlan
+              vlan_id: {get_param: InternalApiNetworkVlanID}
+              device: nic4
+              addresses:
+                -
+                  ip_netmask: {get_param: InternalApiIpSubnet}
+            -
+              type: vlan
+              vlan_id: {get_param: TenantNetworkVlanID}
+              device: nic4
+              addresses:
+                -
+                  ip_netmask: {get_param: TenantIpSubnet}
+            -
+              type: vlan
+              vlan_id: {get_param: StorageNetworkVlanID}
+              device: nic4
+              addresses:
+                -
+                  ip_netmask: {get_param: StorageIpSubnet}
+            -
+              type: ovs_user_bridge
+              name: br-link
+              use_dhcp: false
+              members:
+                -
+                  type: ovs_dpdk_port
+                  name: dpdk0
+                  members:
+                    -
+                      type: interface
+                      name: nic5
+
+
+outputs:
+  OS::stack_id:
+    description: The OsNetConfigImpl resource.
+    value: {get_resource: OsNetConfigImpl}
+

--- a/osp11_ref/nic-configs/controller.yaml
+++ b/osp11_ref/nic-configs/controller.yaml
@@ -1,0 +1,164 @@
+heat_template_version: 2015-04-30
+
+description: >
+  Software Config to drive os-net-config to configure VLANs for the
+  controller role.
+
+parameters:
+  ControlPlaneIp:
+    default: ''
+    description: IP address/subnet on the ctlplane network
+    type: string
+  ExternalIpSubnet:
+    default: ''
+    description: IP address/subnet on the external network
+    type: string
+  InternalApiIpSubnet:
+    default: ''
+    description: IP address/subnet on the internal API network
+    type: string
+  StorageIpSubnet:
+    default: ''
+    description: IP address/subnet on the storage network
+    type: string
+  StorageMgmtIpSubnet:
+    default: ''
+    description: IP address/subnet on the storage mgmt network
+    type: string
+  TenantIpSubnet:
+    default: ''
+    description: IP address/subnet on the tenant network
+    type: string
+  ManagementIpSubnet: # Only populated when including environments/network-management.yaml
+    default: ''
+    description: IP address/subnet on the management network
+    type: string
+  ExternalNetworkVlanID:
+    default: 10
+    description: Vlan ID for the external network traffic.
+    type: number
+  InternalApiNetworkVlanID:
+    default: 20
+    description: Vlan ID for the internal_api network traffic.
+    type: number
+  StorageNetworkVlanID:
+    default: 30
+    description: Vlan ID for the storage network traffic.
+    type: number
+  StorageMgmtNetworkVlanID:
+    default: 40
+    description: Vlan ID for the storage mgmt network traffic.
+    type: number
+  TenantNetworkVlanID:
+    default: 50
+    description: Vlan ID for the tenant network traffic.
+    type: number
+  ManagementNetworkVlanID:
+    default: 60
+    description: Vlan ID for the management network traffic.
+    type: number
+  ExternalInterfaceDefaultRoute:
+    default: '10.0.0.1'
+    description: default route for the external network
+    type: string
+  ControlPlaneSubnetCidr: # Override this via parameter_defaults
+    default: '24'
+    description: The subnet CIDR of the control plane network.
+    type: string
+  DnsServers: # Override this via parameter_defaults
+    default: []
+    description: A list of DNS servers (2 max for some implementations) that will be added to resolv.conf.
+    type: comma_delimited_list
+  EC2MetadataIp: # Override this via parameter_defaults
+    description: The IP address of the EC2 metadata server.
+    type: string
+
+resources:
+  OsNetConfigImpl:
+    type: OS::Heat::StructuredConfig
+    properties:
+      group: os-apply-config
+      config:
+        os_net_config:
+          network_config:
+            -
+              type: interface
+              name: nic2
+              use_dhcp: false
+              dns_servers: {get_param: DnsServers}
+              addresses:
+                -
+                  ip_netmask:
+                    list_join:
+                      - '/'
+                      - - {get_param: ControlPlaneIp}
+                        - {get_param: ControlPlaneSubnetCidr}
+              routes:
+                -
+                  default: false
+                  ip_netmask: 169.254.169.254/32
+                  next_hop: {get_param: EC2MetadataIp}
+            -
+              type: interface
+              name: nic1
+              use_dhcp: false
+              defroute: false
+            -
+              type: interface
+              name: nic3
+              use_dhcp: false
+              defroute: false
+            -
+              type: vlan
+              vlan_id: {get_param: ExternalNetworkVlanID}
+              device: nic3
+              addresses:
+                -
+                  ip_netmask: {get_param: ExternalIpSubnet}
+            -
+              type: interface
+              name: nic4
+              use_dhcp: false
+              defroute: false
+            -
+              type: vlan
+              vlan_id: {get_param: InternalApiNetworkVlanID}
+              device: nic4
+              addresses:
+                -
+                  ip_netmask: {get_param: InternalApiIpSubnet}
+            -
+              type: vlan
+              vlan_id: {get_param: TenantNetworkVlanID}
+              device: nic4
+              addresses:
+                -
+                  ip_netmask: {get_param: TenantIpSubnet}
+            -
+              type: vlan
+              vlan_id: {get_param: StorageNetworkVlanID}
+              device: nic4
+              addresses:
+                -
+                  ip_netmask: {get_param: StorageIpSubnet}
+            -
+              type: vlan
+              vlan_id: {get_param: StorageMgmtNetworkVlanID}
+              device: nic4
+              addresses:
+                -
+                  ip_netmask: {get_param: StorageMgmtIpSubnet}
+            -
+              type: ovs_bridge
+              name: br-link
+              use_dhcp: false
+              members:
+                -
+                  type: interface
+                  name: nic5
+
+outputs:
+  OS::stack_id:
+    description: The OsNetConfigImpl resource.
+    value: {get_resource: OsNetConfigImpl}
+

--- a/osp11_ref/post-install.yaml
+++ b/osp11_ref/post-install.yaml
@@ -1,0 +1,45 @@
+heat_template_version: 2014-10-16
+
+description: >
+  Example extra config for post-deployment
+
+parameters:
+  servers:
+    type: json
+
+resources:
+
+  ExtraDeployments:
+    type: OS::Heat::StructuredDeployments
+    properties:
+      servers:  {get_param: servers}
+      config: {get_resource: ExtraConfig}
+      actions: ['CREATE','UPDATE']
+
+  ExtraConfig:
+    type: OS::Heat::SoftwareConfig
+    properties:
+      group: script
+      config: |
+        #!/bin/bash
+        set -x
+        function tuned_service_dependency() {
+          tuned_service=/usr/lib/systemd/system/tuned.service
+          grep -q "network.target" $tuned_service
+          if [ "$?" -eq 0 ]; then
+              sed -i '/After=.*/s/network.target//g' $tuned_service
+          fi
+          grep -q "Before=.*network.target" $tuned_service
+          if [ ! "$?" -eq 0 ]; then
+              grep -q "Before=.*" $tuned_service
+              if [ "$?" -eq 0 ]; then
+                  sed -i 's/^\(Before=.*\)/\1 network.target openvswitch.service/g' $tuned_service
+              else
+                  sed -i '/After/i Before=network.target openvswitch.service' $tuned_service
+              fi
+          fi
+        }
+
+        if hiera -c /etc/puppet/hiera.yaml service_names | grep -q neutron_ovs_dpdk_agent; then
+            tuned_service_dependency
+        fi


### PR DESCRIPTION
DPDK reference architecture does not mixes compute nodes
with ovs_user_bridge with ovs_bridge. The network isolation
is implemented by either interface or linux_bond. Added
osp11_ref templates which has nic configs based on interface.